### PR TITLE
Added JSON Depth

### DIFF
--- a/PSIdentityNow/Public/New-IDNWObject.ps1
+++ b/PSIdentityNow/Public/New-IDNWObject.ps1
@@ -50,7 +50,7 @@ function New-IDNWObject {
     $Method = 'POST'
 
     # Convert hashtable to JSON
-    $Body = $Data | ConvertTo-Json
+    $Body = $Data | ConvertTo-Json -Depth 99
 
     # Configure the Url
     $url = "$($script:IDNWEnv.BaseAPIUrl)/$ObjectType"

--- a/PSIdentityNow/Public/Set-IDNWObject.ps1
+++ b/PSIdentityNow/Public/Set-IDNWObject.ps1
@@ -55,7 +55,7 @@ function Set-IDNWObject {
     $Method = 'PATCH'
 
     # Convert hashtable to JSON
-    $Body = ConvertTo-Json @($Data)
+    $Body = ConvertTo-Json @($Data) -Depth 99
 
     # Configure the Url
     $url = "$($script:IDNWEnv.BaseAPIUrl)/$ObjectType/$Id"


### PR DESCRIPTION
JSON body was incorrect because resulting JSON was truncated as serialization has exceeded the set depth of 2.