### PR TITLE
Added 'Depth' parameter to ConvertTo-JSON

### DIFF
--- a/PSIdentityNow/Public/New-IDNWObject.ps1
+++ b/PSIdentityNow/Public/New-IDNWObject.ps1
@@ -50,7 +50,7 @@ function New-IDNWObject {
     $Method = 'POST'
 
     # Convert hashtable to JSON
-    $Body = $Data | ConvertTo-Json
+    $Body = $Data | ConvertTo-Json -Depth 100
 
     # Configure the Url
     $url = "$($script:IDNWEnv.BaseAPIUrl)/$ObjectType"

--- a/PSIdentityNow/Public/Set-IDNWObject.ps1
+++ b/PSIdentityNow/Public/Set-IDNWObject.ps1
@@ -55,7 +55,7 @@ function Set-IDNWObject {
     $Method = 'PATCH'
 
     # Convert hashtable to JSON
-    $Body = ConvertTo-Json @($Data)
+    $Body = ConvertTo-Json @($Data) -Depth 100
 
     # Configure the Url
     $url = "$($script:IDNWEnv.BaseAPIUrl)/$ObjectType/$Id"


### PR DESCRIPTION
When the data object that is being passed as a parameter to the New-IDNWObject and Set-IDNWObject had a depth greater than 2, the functions failed with the following error message:

`WARNING: Resulting JSON is truncated as serialization has exceeded the set depth of 2.`

We added '-Depth 100' as a parameter to the ConvertTo-JSON function so it allows for data objects with nested objects (exceeding a set depth of 2).